### PR TITLE
Agrident wedge traduction

### DIFF
--- a/applications/agrident_wedge.md
+++ b/applications/agrident_wedge.md
@@ -13,6 +13,7 @@ The application is composed of two parts:
 
 Prerequisites
 -------------
+
 ### C-One² LF Agrident
 
  - CoreServices version 1.9.0 and above must be installed on the device.
@@ -25,7 +26,7 @@ What is a keyboard wedge?
 
 A keyboard wedge is an application that can acquire data and send it directly into the keyboard buffer, just as if it was typed on a virtual keyboard.
 
-Coppernic's wedge applications add a deeper integration capability by using Android intent in order to send reader's events (successful read or read failure).
+Coppernic's wedge applications add a deeper integration capability by using Android `Intent` in order to send reader's events (successful read or read failure).
 
 
 Agrident settings
@@ -76,7 +77,9 @@ Agrident Wedge Scan
 
  ``` groovy
  // At module level
- implementation(group: 'fr.coppernic.sdk.cpcutils', name: 'CpcUtilsLib', version: '6.13.0', ext: 'aar')
+ dependencies {
+     implementation 'fr.coppernic.sdk.cpcutils:CpcUtilsLib:6.13.0'
+}
  ```
 
 

--- a/applications/iclass_wedge.md
+++ b/applications/iclass_wedge.md
@@ -4,6 +4,7 @@ HID iClass Wedge
 
 Introduction
 ------------
+
 This application demonstrates how to use the HID iClass/LF Prox Wedge application on a C-One² with HID iClass/LF Prox RFID reader.
 The application is composed of two parts:
 
@@ -13,6 +14,7 @@ The application is composed of two parts:
 
 Prerequisites
 -------------
+
 ### C-One² iClass
 
  - CoreServices version 1.9.0 and above must be installed on the device.
@@ -27,6 +29,7 @@ Coppernic's wedge applications add a deeper integration capability by using Andr
 
 iCLass settings
 --------------
+
 iCLass Settings allows confuring wedge for the Sound, Timeout and so on...
 Settings screen is composed of four sections :
   - Service
@@ -66,6 +69,7 @@ Settings screen is composed of four sections :
 
 iClass scan
 ---------
+
  This application just start a scan to read an iClass/LF prox card.
  You can use it remapping this application to on (or more) of the 3 programmable button. You can do it on the device in Settings > Remap key & shortcut.
 

--- a/fr/applications/agrident_wedge.md
+++ b/fr/applications/agrident_wedge.md
@@ -6,54 +6,58 @@ Introduction
 ------------
 Cette application explique comment utiliser l'application Agrident Wedge sur un C-One² disposant d'un lecteur RFID LF Agrident.
 L'application est composée de deux parties:
+
  - Agrident Wedge Settings (AW Settings)
- - Agrident Wedge Scan (AW Scan) 
+ - Agrident Wedge Scan (AW Scan)
 
 
 Prérequis
 ---------
+
 ### C-One² LF Agrident
 
  - CoreServices version 1.9.0 et supérieure doit être installée sur le terminal.
  - Agrident Wedge 2.2.0 et supérieure doit être installée sur le terminal.
 
- Les application sont disponibles sur [F-Droid](www.coppernic.fr/fdroid.apk).
+ Les application sont disponibles sur [CopperApps](copperapps.md) (Disponible en téléchargement [ici](https://coppernic.fr/copperapps.apk)).
 
 Qu'est ce qu'un keyboard wedge?
 -------------------------------
 
-Une application keyboard wedge est une application qui récupère des données et qui les envoient directement dans la zone tampon du clavier, comme si elles avaient été tapées sur un clavier virtuel.
+Une application keyboard wedge est une application qui récupère des données du lecteur et qui les envoie directement dans la zone tampon du clavier, comme si elles avaient été tapées sur un clavier virtuel. Elle sont ensuite insérées automatiquement dans les champs de texte par le système Android.
 
-Les applications Coppernic de type wedge offrent une meilleure intégration grâce à l'utilisation d'intent Android à la place d'évenements du lecteur.(lecture réussie ou non)
+Les applications Coppernic de type wedge offrent une meilleure intégration grâce à l'utilisation d'`Intent` Android en plus des données insérées dans le buffer du clavier. On peut ainsi savoir si la lecture a réussie ou non, récupérer le code d'erreur ou tout simplement récupérer les données du lecteur de manière beaucoup plus réactive. Ces données peuvent être traité par l'application avant affichage à l'opérateur.
 
 
-Paramètres Agrident 
+Paramètres Agrident
 -------------------
 
-Les paramètres d'Agrident Wedge permettent la configuration du son, des délais, et bien d'autres...
+Les paramètres de l'application *Agrident Wedge* permettent la configuration du son, des délais, et bien d'autres...
 
 
 ![](_images/agrident_settings.png)
 
  - Scan Sound: joue un son après une lecture réussie ou non.
- - Scan Display: affiche une icône durant le scan du lecteur.
- - Scan Timeout: paramètre la durée pendant laquelle le lecteur va essayer de lire un tag.
+ - Scan Display: affiche une icône durant la lecture.
+ - Scan Timeout: configure la durée pendant laquelle le lecteur va essayer de lire un tag.
  - Agrident Service startup boot: si activé, le service va ce lancer automatiquement au démarrage du terminal.
- - Continuous Read: le lecteur va lire en permanence jusqu'à ce que le service soit stoppé ou l'écran éteind.
- - Keyboard Wedge: si activé, envoie le résultat au tampon du clavier. Il diffuse toujours des intentions.
- - Scan Enter: ajoute un retour chariot dans le tampon du clavier aux données lues.
- - Remove leading 0: supprime 0 aux premières données envoyées.
+ - Continuous Read: le lecteur va lire en permanence jusqu'à ce que le service soit stoppé ou l'écran éteint.
+ - Keyboard Wedge: si activé, envoie le résultat au clavier. Un `Intent` est toujours envoyé.
+ - Scan Enter: ajoute un retour chariot dans le tampon du clavier après les données lues.
+ - Remove leading 0: supprime le caractère `0` au début des données envoyées.
 
-
- Scanne Agrident Wedge
+ Agrident Wedge Scan
  ---------------------
+
  Cette application lance un scan pour lire un tag LF.
- Vous pouvez utiliser cette application en l'associant avec un (ou plus) bouton programmable. Vous pouvez effectuer cette opération sur le terminal dans Paramètres -> Remap key & shorcut.
+ Vous pouvez utiliser cette application en l'associant avec un (ou plus) bouton programmable. Vous pouvez effectuer cette opération sur le terminal dans `Paramètres` -> `Remap key & shorcut`.
 
 
  Utiliser Agrident Wedge comme un clavier
  ----------------------------------------
- - Associer l'application Agrident Wedge avec un (ou plus) bouton programmable du C-One.
+
+ - Associer l'application *Agrident Wedge Scan* avec un (ou plus) bouton programmable du C-One.
+ - Configurer l'option *Keyboard Wedge* de l'application
  - Appuyer sur le bouton.
  - Les données sont envoyées au système comme des entrées clavier.
 
@@ -76,11 +80,13 @@ Les paramètres d'Agrident Wedge permettent la configuration du son, des délais
 
  ``` groovy
  // Au niveau du module
- implementation(group: 'fr.coppernic.sdk.cpcutils', name: 'CpcUtilsLib', version: '6.13.0', ext: 'aar')
+ dependencies {
+     implementation 'fr.coppernic.sdk.cpcutils:CpcUtilsLib:6.13.0'
+}
  ```
 
 
- - Déclarer un broadcast receiver dans votre class, il recevra les intents en provenance de l'application Agrident Wedge.
+ - Déclarer un `BroadcastReceiver` dans votre classe, il recevra les intents en provenance de l'application *Agrident Wedge*.
 
  ``` java
  private BroadcastReceiver agridentReceiver = new BroadcastReceiver() {
@@ -96,7 +102,7 @@ Les paramètres d'Agrident Wedge permettent la configuration du son, des délais
  };
  ```
 
- - Enregister le receiver, par exemple dans le onStart
+ - Enregister le receiver, par exemple dans la méthode `onStart()`
 
  ``` java
  @Override
@@ -110,7 +116,7 @@ Les paramètres d'Agrident Wedge permettent la configuration du son, des délais
  }
  ```
 
- - Et désenregister le, dans le onStop par exemple:
+ - Et désinscrivez le, dans la méthode `onStop()` par exemple:
 
  ``` java
  @Override
@@ -133,7 +139,7 @@ Les paramètres d'Agrident Wedge permettent la configuration du son, des délais
  }
  ```
 
- Si vous ne voulez pas déclarer CpcUtilsLib dans votre application, voici les valeurs au format string:
+ Si vous ne voulez pas déclarer CpcUtilsLib dans votre application, voici les valeurs des constantes:
 
  ```java
  public static final String ACTION_AGRIDENT_SUCCESS = "fr.coppernic.intent.agridentsuccess";

--- a/fr/applications/agrident_wedge.md
+++ b/fr/applications/agrident_wedge.md
@@ -24,7 +24,7 @@ Prérequis
 Qu'est ce qu'un keyboard wedge?
 -------------------------------
 
-Une application keyboard wedge est une application qui récupère des données du lecteur et qui les envoie directement dans la zone tampon du clavier, comme si elles avaient été tapées sur un clavier virtuel. Elle sont ensuite insérées automatiquement dans les champs de texte par le système Android.
+Une application keyboard wedge est une application qui récupère des données du lecteur et qui les envoie directement dans la zone tampon du clavier, comme si elles avaient été tapées sur un clavier virtuel. Elles sont ensuite insérées automatiquement dans les champs de texte par le système Android.
 
 Les applications Coppernic de type wedge offrent une meilleure intégration grâce à l'utilisation d'`Intent` Android en plus des données insérées dans le buffer du clavier. On peut ainsi savoir si la lecture a réussie ou non, récupérer le code d'erreur ou tout simplement récupérer les données du lecteur de manière beaucoup plus réactive. Ces données peuvent être traité par l'application avant affichage à l'opérateur.
 

--- a/fr/applications/agrident_wedge.md
+++ b/fr/applications/agrident_wedge.md
@@ -40,7 +40,7 @@ Les paramètres de l'application *Agrident Wedge* permettent la configuration du
  - Scan Sound: joue un son après une lecture réussie ou non.
  - Scan Display: affiche une icône durant la lecture.
  - Scan Timeout: configure la durée pendant laquelle le lecteur va essayer de lire un tag.
- - Agrident Service startup boot: si activé, le service va ce lancer automatiquement au démarrage du terminal.
+ - Agrident Service startup boot: si activé, le service va se lancer automatiquement au démarrage du terminal.
  - Continuous Read: le lecteur va lire en permanence jusqu'à ce que le service soit stoppé ou l'écran éteint.
  - Keyboard Wedge: si activé, envoie le résultat au clavier. Un `Intent` est toujours envoyé.
  - Scan Enter: ajoute un retour chariot dans le tampon du clavier après les données lues.
@@ -50,13 +50,13 @@ Les paramètres de l'application *Agrident Wedge* permettent la configuration du
  ---------------------
 
  Cette application lance un scan pour lire un tag LF.
- Vous pouvez utiliser cette application en l'associant avec un (ou plus) bouton programmable. Vous pouvez effectuer cette opération sur le terminal dans `Paramètres` -> `Remap key & shorcut`.
+ Vous pouvez utiliser cette application en l'associant avec un (ou plusieurs) bouton programmable. Vous pouvez effectuer cette opération sur le terminal dans `Paramètres` -> `Remap key & shorcut`.
 
 
  Utiliser Agrident Wedge comme un clavier
  ----------------------------------------
 
- - Associer l'application *Agrident Wedge Scan* avec un (ou plus) bouton programmable du C-One.
+ - Associer l'application *Agrident Wedge Scan* avec un (ou plusieurs) bouton programmable du C-One.
  - Configurer l'option *Keyboard Wedge* de l'application
  - Appuyer sur le bouton.
  - Les données sont envoyées au système comme des entrées clavier.

--- a/fr/applications/agrident_wedge.md
+++ b/fr/applications/agrident_wedge.md
@@ -4,67 +4,67 @@ Agrident Wedge
 
 Introduction
 ------------
-This application demonstrates how to use the Agrident Wedge application on a C-One² with LF Agrident RFID reader.
-The application is composed of two parts:
-
+Cette application explique comment utiliser l'application Agrident Wedge sur un C-One² disposant d'un lecteur RFID LF Agrident.
+L'application est composée de deux parties:
  - Agrident Wedge Settings (AW Settings)
- - Agrident Wedge Scan (AW Scan)
+ - Agrident Wedge Scan (AW Scan) 
 
 
-Prerequisites
--------------
+Prérequis
+---------
 ### C-One² LF Agrident
 
- - CoreServices version 1.9.0 and above must be installed on the device.
- - Agrident Wedge 2.2.0 and above must be installed on the device.
+ - CoreServices version 1.9.0 et supérieure doit être installée sur le terminal.
+ - Agrident Wedge 2.2.0 et supérieure doit être installée sur le terminal.
 
- The applications above can be found on [F-Droid](www.coppernic.fr/fdroid.apk).
+ Les application sont disponibles sur [F-Droid](www.coppernic.fr/fdroid.apk).
 
-What is a keyboard wedge?
--------------------------
+Qu'est ce qu'un keyboard wedge?
+-------------------------------
 
-A keyboard wedge is an application that can acquire data and send it directly in the keyboard buffer, just as if it was typed on a virtual keyboard.
+Une application keyboard wedge est une application qui récupère des données et qui les envoient directement dans la zone tampon du clavier, comme si elles avaient été tapées sur un clavier virtuel.
 
-Coppernic's wedge applications add a deeper integration capability by using Android intent in order to send reader's events (successful read or read failure).
+Les applications Coppernic de type wedge offrent une meilleure intégration grâce à l'utilisation d'intent Android à la place d'évenements du lecteur.(lecture réussie ou non)
 
 
-Agrident settings
---------------
-Agrident Settings allows confuring wedge for the Sound, Timeout and so on...
+Paramètres Agrident 
+-------------------
+
+Les paramètres d'Agrident Wedge permettent la configuration du son, des délais, et bien d'autres...
 
 
 ![](_images/agrident_settings.png)
 
- - Scan Sound: plays a sound after a good or bad read.
- - Scan Display: displays an icon while reader is scanning.
- - Scan Timeout: allows setting time in seconds while the device is trying to read a tag.
- - Agrident Service startup boot: when enabled, the service will start automatically when the device boots.
- - Continuous Read: reads continuously until service is stopped or screen turns off.
- - Keyboard Wedge: when enabled, it will send result to the keyboard buffer. It is still broadcasting Intents.
- - Scan Enter: adds a carriage return of the data read in keyboard buffer.
- - Remove leading 0: Remove 0 from the first data sent.
+ - Scan Sound: joue un son après une lecture réussie ou non.
+ - Scan Display: affiche une icône durant le scan du lecteur.
+ - Scan Timeout: paramètre la durée pendant laquelle le lecteur va essayer de lire un tag.
+ - Agrident Service startup boot: si activé, le service va ce lancer automatiquement au démarrage du terminal.
+ - Continuous Read: le lecteur va lire en permanence jusqu'à ce que le service soit stoppé ou l'écran éteind.
+ - Keyboard Wedge: si activé, envoie le résultat au tampon du clavier. Il diffuse toujours des intentions.
+ - Scan Enter: ajoute un retour chariot dans le tampon du clavier aux données lues.
+ - Remove leading 0: supprime 0 aux premières données envoyées.
 
 
-Agrident Wedge Scan
----------
- This application just starts a scan to read an LF tag.
- You can use it remapping this application to one (or more) of the 3 programmable buttons. You can do it on the device in Settings > Remap key & shortcut.
+ Scanne Agrident Wedge
+ ---------------------
+ Cette application lance un scan pour lire un tag LF.
+ Vous pouvez utiliser cette application en l'associant avec un (ou plus) bouton programmable. Vous pouvez effectuer cette opération sur le terminal dans Paramètres -> Remap key & shorcut.
 
 
- Using Agrident Wedge as a regular keyboard wedge
- --------
- - Remap the Agrident Wedge application to one (or more) of the 3 programmable buttons of the C-One.
- - Push the button.
- - Data will be sent as keyboard entries directly to the system.
+ Utiliser Agrident Wedge comme un clavier
+ ----------------------------------------
+ - Associer l'application Agrident Wedge avec un (ou plus) bouton programmable du C-One.
+ - Appuyer sur le bouton.
+ - Les données sont envoyées au système comme des entrées clavier.
 
 
- Using Agrident Wedge with Intents.
- ---------------------------------
+ Utiliser Agrident Wedge avec des Intents.
+ -----------------------------------------
 
- - For this example, Coppernic Utility library is used. You must declare it in build.gradle:
+ - Pour cet exemple, la librairie utilitaire de Coppernic est utilisée. Vous devez la déclarer dans votre build.gradle:
 
  ``` groovy
- // At project level
+ // Au niveau du projet
  allprojects {
      repositories {
          google()
@@ -75,12 +75,12 @@ Agrident Wedge Scan
  ```
 
  ``` groovy
- // At module level
+ // Au niveau du module
  implementation(group: 'fr.coppernic.sdk.cpcutils', name: 'CpcUtilsLib', version: '6.13.0', ext: 'aar')
  ```
 
 
- - Declare a broadcast receiver in your class, it will receive the intents from the Agrident Wedge application.
+ - Déclarer un broadcast receiver dans votre class, il recevra les intents en provenance de l'application Agrident Wedge.
 
  ``` java
  private BroadcastReceiver agridentReceiver = new BroadcastReceiver() {
@@ -96,7 +96,7 @@ Agrident Wedge Scan
  };
  ```
 
- - Register the receiver, for example in onStart
+ - Enregister le receiver, par exemple dans le onStart
 
  ``` java
  @Override
@@ -107,10 +107,10 @@ Agrident Wedge Scan
      intentFilter.addAction(CpcDefinitions.ACTION_AGRIDENT_SUCCESS);
      intentFilter.addAction(CpcDefinitions.ACTION_AGRIDENT_ERROR);
      registerReceiver(agridentReceiver, intentFilter);
- }    
+ }
  ```
 
- - And unregister it, in onStop for example:
+ - Et désenregister le, dans le onStop par exemple:
 
  ``` java
  @Override
@@ -121,7 +121,7 @@ Agrident Wedge Scan
  }
  ```
 
- - Trig a read:
+ - Déclencher une lecture:
 
  ```java
  private static final String AGRIDENT_WEDGE = "fr.coppernic.tools.cpcagridentwedge";
@@ -133,8 +133,7 @@ Agrident Wedge Scan
  }
  ```
 
- If you don't want to declare CpcUtilsLib in your build, then here are
- string values:
+ Si vous ne voulez pas déclarer CpcUtilsLib dans votre application, voici les valeurs au format string:
 
  ```java
  public static final String ACTION_AGRIDENT_SUCCESS = "fr.coppernic.intent.agridentsuccess";

--- a/fr/applications/iclass_wedge.md
+++ b/fr/applications/iclass_wedge.md
@@ -5,7 +5,7 @@ HID iClass Wedge
 Introduction
 ------------
 
-Cette application montre comment utiliser le lecteur HID iClass/LF Prox Wedge sur un C-One² disposant d'un lecteur HID iClass/LF Prox RFID.
+Cette application montre comment utiliser le lecteur HID iClass/LF Prox Wedge sur un C-One² disposant d'un lecteur RFID HID iClass/LF Prox .
 L'application est composée de deux parties:
 
  - iClass Settings,

--- a/fr/applications/iclass_wedge.md
+++ b/fr/applications/iclass_wedge.md
@@ -1,34 +1,37 @@
 HID iClass Wedge
-=====
+================
 
 
 Introduction
 ------------
-This application demonstrates how to use the HID iClass/LF Prox Wedge application on a C-One² with HID iClass/LF Prox RFID reader.
-The application is composed of two parts:
+
+Cette application montre comment utiliser le lecteur HID iClass/LF Prox Wedge sur un C-One² disposant d'un lecteur HID iClass/LF Prox RFID.
+L'application est composée de deux parties:
 
  - iClass Settings,
  - iClass Scan.
 
 
-Prerequisites
--------------
+Prérequis
+---------
+
 ### C-One² iClass
 
- - CoreServices version 1.9.0 and above must be installed on the device.
+ - CoreServices à la version version 1.9.0 ou supérieure doit être installée sur le terminal.
 
-What is a keyboard wedge?
--------------------------
+Qu'est ce qu'un keyboard wedge?
+-------------------------------
 
-A keyboard wedge is an application that can acquire data and send it directly in the keyboard buffer, just as if it was typed on a virtual keyboard.
+Une application keyboard wedge est une application qui récupère des données du lecteur et qui les envoie directement dans la zone tampon du clavier, comme si elles avaient été tapées sur un clavier virtuel. Elle sont ensuite insérées automatiquement dans les champs de texte par le système Android.
 
-Coppernic's wedge applications add a deeper integration capability by using Android intent in order to send reader's events (successful read or read failure).
+Les applications Coppernic de type wedge offrent une meilleure intégration grâce à l'utilisation d'`Intent` Android en plus des données insérées dans le buffer du clavier. On peut ainsi savoir si la lecture a réussie ou non, récupérer le code d'erreur ou tout simplement récupérer les données du lecteur de manière beaucoup plus réactive. Ces données peuvent être traité par l'application avant affichage à l'opérateur.
 
 
-iCLass settings
---------------
-iCLass Settings allows confuring wedge for the Sound, Timeout and so on...
-Settings screen is composed of four sections :
+Paramètres iCLass
+-----------------
+
+Les paramètres d'HID iClass Wedge permettent la configuration du son, des délais, et bien d'autres...
+L'écran de paramètres est composé de 4 sections :
   - Service
   - Scan
   - Keyboard wedge
@@ -38,45 +41,47 @@ Settings screen is composed of four sections :
 ![](_images/iclass_settings.png) ![](_images/iclass_settings_2.png)
 
 
-1.Service
-   - Enable service : you can start or stop the service with this option.
-   - Hid iClass Service startup boot : when it is enabled, the service will start
-   automatically when the device boot.
-   - On/off reader for each scan : when enabled, it will power off reader after scanning
-   (either for bad or good read). It will save battery, but can be a little bit longer
-   to read as you will need to power on the reader every time.
+ 1.Service
+   - **Enable service** : Démarre ou arrête le service.
+   - **Hid iClass Service startup boot** : Permet d'activer le lancement du service au démarrage du terminal.
+   - **On/off reader for each scan** : si activé, le lecteur s'éteindra après une lecture.(qu'elle soit réussie ou non).
+Économise la batterie, mais peut augmenter le temps de lecture car le lecteur doit démarrer à chaque fois.
 
 
  2.Scan
-  - Sound : play a sound after a good or bad scan.
-  - Display : display an icon while scanning.
-  - Timeout : allow setting time in seconds while the device is trying to read a tag.
+  - **Sound** : joue un son après une lecture réussie ou non.
+  - **Display** : affiche une icône durant le scan du lecteur.
+  - **Timeout** : paramètre la durée pendant laquelle le lecteur va essayer de lire un tag.
 
 
  3.Keyboard Wedge
-  - Enable Keyboard : when enabled, it will send result to the keyboard buffer. It is still broadcasting Intents.
-  - Scan Enter : add a carriage return of the data reader.
-  - Data Send : you can choose either between card number and facility code to send to the keyboard buffer.
-  - Facility code : depending on the card you want to read, card number will be different if card has a facility code or not.
+  - **Enable Keyboard** : si activé, envoie le résultat au tampon du clavier. Il diffuse toujours des `Intent`.
+  - **Scan Enter** : ajoute un retour chariot aux données lues par la lecture.
+  - **Data Send** : vous pouvez choisir entre le numéro de carte et le `Facility code` à envoyer au clavier.
+  - **Facility code** : dépend de la carte que vous voulez lire, le numéro de carte sera différent si la carte à un `Facility code` ou non.
 
 
-  4.Reader configuration
-   - Hid Card configuration : allows using an HID card configuration. You need to present and hold the card front of the antenna until the configuration is finished.
+ 4.Reader configuration
+   - Hid Card configuration : permet l'utilisation d'une carte de configuration HID. Vous devez présenter la carte devant l'antenne
+ et la maintenir jusqu'à ce que la configuration soit finie.
 
 
 iClass scan
----------
- This application just start a scan to read an iClass/LF prox card.
- You can use it remapping this application to on (or more) of the 3 programmable button. You can do it on the device in Settings > Remap key & shortcut.
+-----------
+
+ Cette application lance un scan pour lire une carte iClass/LF prox.
+ Vous pouvez utiliser cette application en l'associant avec un (ou plusieurs) bouton programmable. Vous pouvez
+ effectuer cette opération sur le terminal dans Paramètres -> Remap key & shorcut.
 
 
-Using iClass Wedge with intents in your application
----------------------------------
 
-- For this example, Coppernic Core library is used. You must declare it in build.gradle.
+Utiliser iClass Wedge avec intents dans votre application
+---------------------------------------------------------
+
+- POur cet exemple, la bibliothèqe CpcCore de Coppernic est utilisée. Vous devez la déclarer dans votre build.gradle.
 
 ``` groovy
-// At project level
+// Au niveau du projet
 allprojects {
     repositories {
         google()
@@ -87,12 +92,12 @@ allprojects {
 ```
 
 ``` groovy
-// At module level
-implementation 'fr.coppernic.sdk.core:CpcCore:1.9.1'
+// Au niveau du module
+implementation 'fr.coppernic.sdk.core:CpcCore:1.11.1'
 ```
 
 
-- Declare a broadcast receiver in your class, it will receive the intents from the iClass Wedge application.
+- Déclarer un `BroadcastReceiver` dans votre classe, il recevra les `Intent` en provenance de l'application iClass Wedge.
 
 ``` java
 private BroadcastReceiver iClassReceiver = new BroadcastReceiver() {
@@ -114,7 +119,7 @@ private BroadcastReceiver iClassReceiver = new BroadcastReceiver() {
 };
 ```
 
-- Register the receiver, for example in onStart:
+- Enregistrer le `BroadcastReceiver`, par exemple dans la méthode `onStart()`:
 
 ``` java
 @Override
@@ -128,7 +133,7 @@ protected void onStart() {
 }    
 ```
 
-- And unregister it, in onStop for example:
+- et le désincrire, dans la méthode `onStop()` par exemple:
 
 ``` java
 @Override
@@ -139,7 +144,7 @@ protected void onStop() {
 }
 ```
 
-- Trig a read:
+- Déclencher une lecture:
 
 ```java
 
@@ -154,8 +159,7 @@ if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
 }
 ```
 
-If you don't want to declare CpcCore in your build, then here are
-string values:
+Si vous ne voulez pas déclarer *CpcCore* dans votre application, voici les valeurs au format string:
 
 ```java
 //Hid Iclass

--- a/fr/applications/iclass_wedge.md
+++ b/fr/applications/iclass_wedge.md
@@ -78,7 +78,7 @@ iClass scan
 Utiliser iClass Wedge avec intents dans votre application
 ---------------------------------------------------------
 
-- POur cet exemple, la bibliothèqe CpcCore de Coppernic est utilisée. Vous devez la déclarer dans votre build.gradle.
+- Pour cet exemple, la bibliothèqe CpcCore de Coppernic est utilisée. Vous devez la déclarer dans votre build.gradle.
 
 ``` groovy
 // Au niveau du projet


### PR DESCRIPTION
Voici les règles de traduction : 
- Utiliser de préférence le nom dans le code avec des `` comme quote. Exemple `BroadcastReceiver` au lieu "broadcast receiver"
- Lors de l'affichage d'une liste de paramètre, mettre les paramètres en gras. Exemple : 
   - **service**: bla bla bla
   - **enable**: bli bli
- Ecrire le vocabulaire POO en français : classe, surcharge, héritage, etc.
- Quand le français n'est pas jusdicieux, utiliser le mot anglais avec les "" ou des '' ou en *italique*
