### PR TITLE
Fr4

### DIFF
--- a/fr/applications/agrident_wedge.md
+++ b/fr/applications/agrident_wedge.md
@@ -19,7 +19,7 @@ Prérequis
  - CoreServices version 1.9.0 et supérieure doit être installée sur le terminal.
  - Agrident Wedge 2.2.0 et supérieure doit être installée sur le terminal.
 
- Les application sont disponibles sur [CopperApps](copperapps.md) (Disponible en téléchargement [ici](https://coppernic.fr/copperapps.apk)).
+ Les application sont disponibles sur [CopperApps](/fr/copperapps.md) (Disponible en téléchargement [ici](https://coppernic.fr/copperapps.apk)).
 
 Qu'est ce qu'un keyboard wedge?
 -------------------------------

--- a/fr/applications/management.md
+++ b/fr/applications/management.md
@@ -1,18 +1,18 @@
-App management
-==============
+Gestion des applications
+========================
 
-Application update
-------------------
+Mise à jour des applications
+----------------------------
 
-There are several ways to keep your applications up to date on your Coppernic devices
+Il y a plusieurs manières de tenir vos applications à jour sur vos terminaux Coppernic
 
-- **ADB** : Very handful at development stage. This tool from google allows you to do many things with your device. https://developer.android.com/studio/command-line/adb
+- **ADB** : Très utile en phase de développement. Cet outil de Google vous permet de faire beaucoup de choses sur votre terminal. https://developer.android.com/studio/command-line/adb
 
-- **SD Card** : You can put an apk in device's memory (SD Card or internal memeory), browse to your file and click on it for installation.
+- **SD Card** : Vous pouvez charger un apk dans la mémoire du terminal (Carte SD ou mémoire interne), accédez à votre fichier et cliquez dessus pour l'installer.
 
-- **Google Play** : On devices where [GMS](https://www.android.com/intl/en_us/gms/) are available, you can deploy your application on an market place such as Google Play.
+- **Google Play** : Sur les terminaux où les services [GMS](https://www.android.com/intl/fr_fr/gms/) sont disponibles, vous pouvez déployer votre application sur un market place tel que Google Play.
 
-- **EMM** : You can deploy your app wit an EMM such as MobiControl from Soti.
+- **EMM** : Vous pouvez déployer votre application avec un EMM tel que MobiControl de Soti.
 
-Both F-Droid and MobiControl can update your application even when device is kiosked.
-We could also give some pieces of advice to choose the kiosk application that's right for you.
+CopperApps et MobiControl peuvent mettre à jour votre application même lorsque l'appareil est kiosqué.
+Nous pourrions également vous donner quelques conseils pour choisir l'application de diffusion qui vous convient.

--- a/fr/barcode/manager.md
+++ b/fr/barcode/manager.md
@@ -1,61 +1,61 @@
 Barcode Manager
 ==============
 
-> For C-One and C-five :
-> Old documentation [here](https://github.com/Coppernic/ScanSample/blob/1.0.0/README.md)
+> Pour C-One et C-five :
+> Ancienne documentation [ici](https://github.com/Coppernic/ScanSample/blob/1.0.0/README.md)
 
-API to use barcode scanner through Barcode Manager service.
+API pour utiliser le scanner de codes à barres via le service Barcode Manager.
 
-There are 2 ways to trigger a barcode reading:
+Il y a 2 manières de déclencher la lecture d'un code à barres:
 
- - remap a physical button to barcode scan function
- - send an intent
+ - affecter un bouton physique à la fonction scan de code barre.
+ - envoyer un *Intent*
 
-## Supported devices
+## Terminaux compatibles
 
-- C-One² and C-One² e-ID
+- C-One² et C-One² e-ID
 - IDPlatform
 
-This API is almost the same that the old one. The main differences is that for *C-One* and *C-five* devices,
-`barcode service` is hosted inside `CpcSystemServices` application. For *C-One²* familly and *ID Platform*, `barcode service`
-is hosted inside `Barcode Manager` application. `applicationId` is different for these apps so
-`Intents` used for controlling barcode reader have different target compoenent names.
+Cette API est presque la même que l'ancienne. Les principales différences sont :
+- pour les appareils *C-One* and *C-five*,`barcode service` est contenu dans
+ l'application `CpcSystemServices`. Pour la famille des *C-One²* et
+ *ID Platform*, `barcode service` est contenu dans l'application `Barcode Manager`.
+ - l'`applicationId` est différent pour ces applications donc les `Intents` utilisés pour contrôler le lecteur de code barres ont un `ComponentName` différents.
 
-For instance, on *C-One²* we call `Intent.setPackage()` like this :
+Par exemple, sur *C-One²* nous utilisons `Intent.setPackage()` de cette façon :
 
 ```java
 intent.setPackage(OsHelper.getSystemServicePackage(context, "fr.coppernic.features.barcode"));
 ```
 
-on *C-five*, we call `Intent.setPackage()` like this :
+sur *C-five*, nous utlisons `Intent.setPackage()` de cette façon :
 
 ```java
 intent.setPackage(OsHelper.getSystemServicePackage(context));
 ```
 
-## Remap a physical button to barcode reading
+## Associer un bouton physique à la lecture de code barres
 
-In Android settings application, go to remap key & shortcuts (may change on different devices), then remap a key to SCAN or Barcode Scan
- (device dependent).
+Dans l'application de paramètres d'Android, aller à <kbd>remap key & shortcuts</kbd> (peut changer selon les appareils), et associer un bouton à <kbd>SCAN</kbd> ou <kbd>Barcode Scan</kbd> (en fonction du terminal).
 
 ## Intents
 
-This service can respond to `Intents`. There are two options to communicate via `Intents`:
+Ce service répond aux `Intents`. Il y a 2 façons de communiquer via `Intents`:
 
-- add a dependency to CpcBarcode library and use its helper function
-- build an `Intent` from scratch and use it
+- ajouter une dépendance à la librairie CpcBarcode et utiliser ses fonctions *Helper*
+- développer un `Intent` from scratch et l'utiliser
 
-In every cases, you shall declare a permission to be able to communicate with the service.
+Dans tous les cas, vous devrez déclarer une permission pour être capable de communiquer avec le service.
 
 - **Permissions**
 
-You shall declare `fr.coppernic.permission.BARCODE` permission into your manifest:
+Vous devez déclarer la permission `fr.coppernic.permission.BARCODE` dans votre manifest:
 
 ```xml
     <uses-permission android:name="fr.coppernic.permission.BARCODE" />
 ```
 
-You also need to ask for this permission explicitly:
+Et vous devez également explicitement demander cette permission:
 
 ```java
 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
@@ -65,11 +65,11 @@ if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
 
 ### Intents via CpcBarcode
 
-- **Add CpcBarcode dependency**
+- **Ajout de la dépendance CpcBarcode**
 
-More information [here](https://developer.coppernic.fr/#/barcode/library)
+Plus d'informations [ici](https://developer.coppernic.fr/#/barcode/library)
 
-- **Start service**
+- **Démarrer le service**
 
 ```java
 ComponentName cn = BarcodeReader.ServiceManager.startService(context);
@@ -78,7 +78,7 @@ if(cn == null) {
 }
 ```
 
-- **Stop service**
+- **Arrêter le service**
 
 ```java
 ComponentName cn = BarcodeReader.ServiceManager.stopService(context);
@@ -87,7 +87,7 @@ if(cn == null) {
 }
 ```
 
-- **Trig a scan**
+- **Déclencher un scan**
 
 ```java
 ComponentName cn = BarcodeReader.ServiceManager.startScan(context);
@@ -96,7 +96,7 @@ if(cn == null) {
 }
 ```
 
-- **Stop a scan**
+- **Arrêter un scan**
 
 ```java
 ComponentName cn = BarcodeReader.ServiceManager.stopScan(context);
@@ -105,9 +105,9 @@ if(cn == null) {
 }
 ```
 
-### Intents with CpcCore
+### Intents avec CpcCore
 
-#### Start service
+#### Démarrer le service
 
 ```java
 import fr.coppernic.sdk.core.Defines;
@@ -131,7 +131,7 @@ public void startScan(){
 }
 ```
 
-#### Stop service
+#### Arrêter le service
 
 ```java
 import fr.coppernic.sdk.core.Defines;
@@ -155,7 +155,7 @@ public void startScan(){
 }
 ```
 
-#### Trig a scan
+#### Déclencher un scan
 
 ```java
 import fr.coppernic.sdk.core.Defines;
@@ -179,12 +179,11 @@ public void startScan(){
 }
 ```
 
-When reader is in continuous mode, it shall be stopped explicitly, **even if a barcode
-is read**. Otherwise, it is stopped automatically by a read or a timeout.
+Quand le lecteur est en lecture continue, il doit être arrêté de façon explicite, **même si un code barres est lu**. Autrement, il est arrêté automatiquement par une lecture ou un timeout.
 
-#### Stop a scan
+#### Arrêter un scan
 
-Stopping a scan is needed when the reader is in continuous mode.
+Arrêter un scan est requis quand le lecteur est en lecture continue.
 
 ```java
 import fr.coppernic.sdk.core.Defines;
@@ -208,9 +207,9 @@ public void stopScan(){
 }
 ```
 
-### Get scan result
+### Récupérer le résultat d'un scan
 
- - Register a broadcast receiver
+ - Enregistrer un broadcast receiver
 
 ```java
 import fr.coppernic.sdk.core.Defines;
@@ -237,7 +236,7 @@ public class Example extends android.app.Activity {
 }
 ```
 
- - Get the result
+ - Récupérer le résultat
 
 
 ```java
@@ -261,10 +260,10 @@ public class Example extends android.app.Activity {
 }
 ```
 
-Intent's extras are :
- - **Defines.Keys.KEY_RESULT**: `int`, result of the scan. You can use `CpcResult.getResultFromOrdinal(int)` to get a `RESULT`
- - **Defines.Keys.KEY_BARCODE_DATA**: `String`, data scanned. Available only when result is `RESULT.OK`
- - **Defines.Keys.KEY_BARCODE_DATA_BYTES**: `byte[]`, data scanned in byte array. Available only when result is `RESULT.OK`
+Les extras des Intents sont :
+ - **Defines.Keys.KEY_RESULT**: `int`, résultat du scan. Vous pouvez utiliser `CpcResult.getResultFromOrdinal(int)` pour avoir un `RESULT`
+ - **Defines.Keys.KEY_BARCODE_DATA**: `String`, les données scannées. Disponibles uniquement quand le résultat est `RESULT.OK`
+ - **Defines.Keys.KEY_BARCODE_DATA_BYTES**: `byte[]`, les données scannées en tableau de bytes. Disponibles uniquement quand le résultat est `RESULT.OK`
 
 ### Defines
 
@@ -282,38 +281,38 @@ Intent's extras are :
      - IDPlatform : `"fr.coppernic.features.barcode.idplatform"`
      - ...
 
-## Configure the barcode's service
+## Configurer le service de code barres
 
-Barcode reader can be configured via Barcode Manager application. This application is usually installed on devices.
-It is also available on [F-Droid](https://developer.coppernic.fr/#/fdroid).
+Le lecteur de code barres peut être configuré via l'application **Barcode Manager**. Cette application est habituellement installée sur les terminaux.
+Elle est également disponible sur [CopperApps](/fr/copperapps).
 
-#### General
+#### Général
 
-* Scan sound: play a sound when scan is ended or not
-* Scan display: display/hide scan indicator on screen (Set `false` to this option unless you know what you are doing)
-* Continuous mode: enable/disable continuous mode (scan until button is released or barcode is read)
-* Scan timeout: scan timeout
-* Barcode service startup at boot: enable/disable automatic barcode service start when device boot is finished
-* Keep barcode reader opened: if checked, it improves scan speed
-* Keyboard wedge: send data to input buffer in addition to intent
-* Keyboard fast wedge: use faster keyboard wedge, an additional keyboard application needs to be installed
-* Search and replace: use regular expression to search for a pattern in data read and replace it by another value
+* **Scan sound** : joue un son avec une lecture réussie ou non
+* **Scan display** : affiche/cache un indicateur de scan à l'écran (Régler cette option à `false` sauf si vous savez ce que vous faites)
+* **Continuous mode** : active/désactive la lecture continue (scan jusqu'à ce que le bouton soit relâché ou qu'un code barre soit lu)
+* **Scan timeout** : délai de scan
+* **Barcode service startup at boot** : active/désactive le démarre automatique du service Barcode quand l'appareil a fini de démarrer.
+* **Keep barcode reader opened**: si sélectionné, améliore la vitesse de lecture
+* **Keyboard wedge**: envoie les données au tampon d'entrée en plus de l'intent
+* **Keyboard fast wedge**: utilise un keyboard wedge plus rapide, une application clavier supplémentaire doit être installée
+* **Search and replace**: utilise une expression régulière pour chercher un pattern dans les données et les remplacer par une autre valeur
 
-#### Barcode reader
+#### Lecteur de code à barres
 
-Barcode reader specific settings.
+Paramètres spécifique au lecteur de code à barre.
 
-#### Parameters
+#### Paramètres
 
-Depend on devices.
+Dépend de l'appareil.
 
 #### Symbologies
 
-Allow user to enable/disable symbologies, to add suffix and prefix, to add minimal and maximum lengths that can be read.
+Permet à l'utilisateur d'activer/désactiver des symbologies, d'ajouter des suffixes et préfixes, d'ajouter une taille minimale et maximale à ce qui peut être lu.
 
-### Using CpcBarcode library
+### Utiliser la librairie CpcBarcode
 
-To configure the service, you shall depend on **CpcBarcode** available in SDK.
+Pour configurer le service, vous devez utiliser **CpcBarcode** disponible dans le SDK.
 
 ```java
 import fr.coppernic.lib.barcode.core.GlobalConfig;

--- a/fr/build.md
+++ b/fr/build.md
@@ -1,15 +1,16 @@
 Build
 ======
 
-We are supporting [Gradle](https://developer.android.com/studio/build) build system that comes with Android ecosystem.
-We are not supporting other build system such as Xamarin, Cordova, Flutter or old Android build system with Eclipse and Ant.
+Coppernic travaille avec le système de build [Gradle](https://developer.android.com/studio/build) fourni avec l'écosystème Android.
+Nous ne fournissons pas de support avec les autres systèmes de build tel que Cordova, Flutter ou les anciens systèmes avec Eclipse et Ant. Nous faisons de temps en temps
+une exception pour Xamarin.
 
-Repository
-----------
+Dépôt
+-----
 
-Coppernic's libs are stored in [artifactory ](https://artifactory.coppernic.fr/artifactory/webapp/#/home).
+Les bibliothèques fournies par Coppernic sont stockées sur [artifactory ](https://artifactory.coppernic.fr/artifactory/webapp/#/home).
 
-On your `build.gradle` file add a repository:
+Ajouter un dépôt dans le fichier `build.gradle`
 
 ```groovy
 repositories {
@@ -20,10 +21,10 @@ repositories {
 }
 ```
 
-Dependencies
-------------
+Dépendances
+-----------
 
-You can then add Coppernic's dependencies in your build:
+Vous pouvez ensuite ajouter les dépendances de votre application:
 
 ```groovy
 dependencies {

--- a/fr/core.md
+++ b/fr/core.md
@@ -21,23 +21,23 @@ dependencies {
 }
 ```
 
- * Last versions of libs can be found in [artifactory](https://artifactory.coppernic.fr/artifactory/webapp/#/home).
- * `implementation` is a key work of Android gradle plugin 3.x.x, if you are using an older plugin, consider using `compile` instead.
+ * Les dernières versions de libs sont disponible sur [artifactory](https://artifactory.coppernic.fr/artifactory/webapp/#/home).
+ * `implementation` est un mot clé du plugin Gradle 3.x.x pour Android, si vous utilisez un plugin plus ancien, utilisez `compile` à la place.
 
 HDK
 ---
 
-How to use HDK on:
+Comment utiliser HDK sur:
 
- * [C-One & C-One² family](fr/core/hdk_cone.md)
+ * [Famille des C-One & C-One²](/fr/core/hdk_cone.md)
 
 Power
 -----
 
- - [power package](fr/core/power.md)
+ - [Alimentation](/fr/core/power.md)
 
-Others
---------
+Autres
+------
 
- * [Settings](fr/core/settings.md)
- * [Key Mapping](fr/core/mapping.md)
+ * [Paramètres](/fr/core/settings.md)
+ * [Mappage des touches](/fr/core/mapping.md)

--- a/fr/core/hdk_cone.md
+++ b/fr/core/hdk_cone.md
@@ -1,21 +1,21 @@
-HDK for C-One
+HDK pour C-One
 =============
 
-Don't known what a C-One is ? The answer is [here](https://www.coppernic.fr/prehome-mobility-fr/).
+Si vous ne savez pas ce qu'est un C-One? La réponse est [ici](https://www.coppernic.fr/prehome-mobility-fr/).
 
-HDK API is designed with [RxJava2](https://github.com/ReactiveX/RxJava).
+L'API HDK a été conçue avec [RxJava2](https://github.com/ReactiveX/RxJava).
 
-Prerequisites
--------------
+Prérequis
+---------
 
-For first generation of products, app **CpcSystemServices** at version 2.1.0 or above needs to be installed on device.
-For [second generation](quickstart.md) **CoreService** app must be installed instead of **CpcSystemServices**.
-Please contact [Coppernic Support](support@coppernic.fr) in case of difficulties.
+Pour la première génération de produits, l'application **CpcSystemServices** à la version 2.1.0 ou supérieure doit être installée sur le terminal.
+Pour la [seconde génération](/fr/quickstart.md) **CoreService** doit être installée au lieu de **CpcSystemServices**.
+Vous pouvez contacter le [Support Coppernic](support@coppernic.fr) en cas de difficultés.
 
-Use Pins of C-One's expansion port
-----------------------------------
+Utiliser les pins du port d'expansion du C-One
+----------------------------------------------
 
-* Get a GpioPort instance:
+* Récupérer une instance de GpioPort :
 
 ```java
 private GpioPort gpioPort;
@@ -35,17 +35,17 @@ public void onStart() {
 }
 ```
 
-* Use it:
+* Bagoter la pin:
 
 ```java
 RESULT res = gpioPort.setPin1(true)
 ```
 
-Observe input pin state
------------------------
+Observer l'état de la pin d'entrée
+----------------------------------
 
 ```java
-//Register an observer to the input state
+//Enregistrer un observer sur l'état de la pin d'entrée
 Disposable d = GpioPort.observeInputPin4(getContext(), 200, TimeUnit.MILLISECONDS)
                 // Be notified only when value is changing
                 .distinctUntilChanged()
@@ -56,6 +56,6 @@ Disposable d = GpioPort.observeInputPin4(getContext(), 200, TimeUnit.MILLISECOND
                         //Do something
                     }
                 });
-//Dispose the observer when you are done
+//Disposer l'observer quand vous avez fini
 d.dispose()
 ```

--- a/fr/quality.md
+++ b/fr/quality.md
@@ -1,24 +1,21 @@
-Quality
+Qualité
 =======
 
-## Generalities
+## Généralités
 
-While developping your application on our device, please follow guidelines
-from google :
+Durant le développement de votre application sur notre terminal, merci de suivre les recommandations de Google:
 
-[Core App Quality](https://developer.android.com/docs/quality-guidelines/core-app-quality)
+[Qualité des applications](https://developer.android.com/docs/quality-guidelines/core-app-quality)
 
-Please also read google document about
-[Battery Life Optimization](https://developer.android.com/topic/performance/power)
+Merci de lire aussi le document de Google sur [l'optimisation de la durée de vie de la batterie](https://developer.android.com/topic/performance/power)
 
 ## RFID
 
-Looking for a card (Hunting) can be power consuming. Please implement every
-strategies that are fine for you to decrease time where RFID reader is in use.
+La recherche d'une carte (Chasse) peut être consommateur de courant. Veuillez mettre en place
+toutes les solutions que vous jugerez utile pour réduire le temps d'utilisation de votre lecteur RFID.
 
-For instance, during hunt time, RF field can be up during 200ms and then
-turned off during 800ms. These settings ensure that user experience
-will not be affected and preserve battery life.
+Par exemple, durant le temps de chasse, le champ électromagnétique peut être alimenté pendant 200ms puis éteint pendant 800ms.
+Ces paramètres assurent que l'expérience utilisateur ne sera pas affecté et préserve l'autonomie de la batterie.
 
-Please make sure that when screen is turned off or when operator is leaving
-your application (or RFID related screens), then all peripherals are turned off.
+Assurez-vous lorsque l'écran s'éteint ou quand l'utilisateur quitte votre application (ou les écrans liés à la RFID),
+que tous les périphériques s'éteignent également.

--- a/fr/quickstart.md
+++ b/fr/quickstart.md
@@ -19,6 +19,6 @@ Sur la première génération de produits Coppernic, le service s'appelle `CpcSy
 
 Si aucune des deux applications `CpcSystemServices` ou `CoreServices` n'est installé, les samples Coppernic ne pourront pas fonctionner correctement.
 
-Ces applications sont disponibles sur [CopperApps](copperapps.md).
+Ces applications sont disponibles sur [CopperApps](/fr/copperapps.md).
 
 Une fois le service installé, les [samples](https://github.com/Coppernic) pourront fonctionner correctement.

--- a/fr/quickstart.md
+++ b/fr/quickstart.md
@@ -1,25 +1,24 @@
-Getting started
+Pour commencer
 ===============
 
-On Coppernic's Android products, a service is installed that allow user application to perform special tasks on device. On first generation
-of Coppernic's products it is called `CpcSystemServices`, on second generation, it is called `CoreServices`.
+Sur les produits Coppernic, un service est installé pour permettre aux applications clientes d'effectuer des actions privilégiées comme l'alimentation des périphériques
+ou alors établir une liaison série.
+Sur la première génération de produits Coppernic, le service s'appelle `CpcSystemServices`, sur la deuxième génération, `CoreServices`.
 
-**First generation products**
+**Produits de première génération**
 
 - C-Cone
 - C-One e-ID
 - C-five
 
-**Second generation products**
+**Produits de deuxième génération**
 
 - C-One²
 - C-One² e-ID
 - ID Platform
 
-If there is no `CpcSystemServices` or `CoreServices`, then Coppernic's samples will not work as expected.
+Si aucune des deux applications `CpcSystemServices` ou `CoreServices` n'est installé, les samples Coppernic ne pourront pas fonctionner correctement.
 
-These applications are available on [CopperApps](fr/copperapps.md).
+Ces applications sont disponibles sur [CopperApps](copperapps.md).
 
-Once Services app is installed, [samples](https://github.com/Coppernic) can work.
-
-Now, let's see how to add Coppernic's libs on your [build](fr/build.md).
+Une fois le service installé, les [samples](https://github.com/Coppernic) pourront fonctionner correctement.


### PR DESCRIPTION
Voici les règles de traduction : 
- Utiliser de préférence le nom dans le code avec des `` comme quote. Exemple `BroadcastReceiver` au lieu "broadcast receiver"
- Lors de l'affichage d'une liste de paramètre, mettre les paramètres en gras. Exemple : 
   - **service**: bla bla bla
   - **enable**: bli bli
- Ecrire le vocabulaire POO en français : classe, surcharge, héritage, etc.
- Quand le français n'est pas jusdicieux, utiliser le mot anglais avec les "" ou des '' ou en *italique*
